### PR TITLE
Add option to force display a nav type

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -41,6 +41,31 @@ div.p-footer-inner {
 }`;
   }
 
+  switch (storage.topicNavigationMode) {
+    case "simple":
+      css += `
+/* Force display simple nav */
+.pageNavWrapper.pageNavWrapper--mixed .pageNav {
+  display: none;
+}
+
+.pageNavWrapper.pageNavWrapper--mixed .pageNavSimple {
+  display: inline-flex;
+}`;
+      break;
+    case "advanced":
+      css += `
+/* Force display advanced nav */
+.pageNavWrapper.pageNavWrapper--mixed .pageNav {
+  display: block;
+}
+
+.pageNavWrapper.pageNavWrapper--mixed .pageNavSimple {
+  display: none;
+}`;
+      break;
+  }
+
   return css;
 }
 
@@ -51,6 +76,7 @@ chrome.runtime.onInstalled.addListener(async () => {
     postImageHeightLimit: false,
     limitPageWidth: false,
     hideSignatureImages: false,
+    topicNavigationMode: false,
   };
 
   chrome.storage.sync.set({

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,6 +51,21 @@ const limitPageWidthOptions = [
   },
 ];
 
+const topicNavigationModeOptions = [
+  {
+    title: "Standard",
+    value: false,
+  },
+  {
+    title: "Einfach",
+    value: "simple",
+  },
+  {
+    title: "Erweitert",
+    value: "advanced",
+  },
+];
+
 async function reload() {
   const tabs = await chrome.tabs.query({
     url: "*://*.oyle-community.de/*",
@@ -136,6 +151,18 @@ const addonStore = useAddonStore();
           subtitle="Setzt die Breite aller Icons auf den gleichen Wert, um gleichmäßige Abstände zu erzeugen."
           lines="three"
         />
+        <v-list-subheader>Themen</v-list-subheader>
+        <v-list-item>
+          <v-select
+            :items="topicNavigationModeOptions"
+            label="Navigationsmodus"
+            :model-value="addonStore.storage.topicNavigationMode"
+            hide-details
+            @update:modelValue="
+              addonStore.setItem('topicNavigationMode', $event)
+            "
+          />
+        </v-list-item>
       </v-list>
       <v-footer app class="pa-0">
         <div class="px-4 py-2 bg-secondary w-100 d-flex">


### PR DESCRIPTION
Neue Einstellung, um den Typ der Navigationsleiste in Themen zu forcieren.

Standardmäßig wird der Typ "Einfach" in der Mobilansicht, und der Typ "Erweitert" in der Desktopansicht angezeigt. Mit dieser Eisntellung lässt sich der Typ in jeder Ansicht forcieren.